### PR TITLE
fix password handler to support Autorization Basic header

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
@@ -88,8 +88,13 @@ class Password extends GrantHandler {
   case class userCtx(username: String, password: String)
 
   def getHeader(request: AuthorizationRequest): Option[userCtx] = {
-    request.headers.get("Authorization").headOption.flatMap { encoded =>
-      new String(decodeBase64(encoded.toString.getBytes)).split(":").toList match {
+    request.headers.get("Authorization").headOption.flatMap{ authParam =>
+
+      val encoded = authParam.headOption.flatMap{ r =>
+        r.split(" ").filter(x => !x.contains("Basic")).headOption
+      }.getOrElse(throw new InvalidRequest("Invalid HTTP Header. Authorization format not supported"))
+
+      new String(decodeBase64(encoded.getBytes)).split(":").toList match {
         case username :: password :: Nil => Some(userCtx(username, password))
         case _ => None
       }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/TokenEndPointSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/TokenEndPointSpec.scala
@@ -95,7 +95,7 @@ class TokenEndPointSpec extends FlatSpec with ScalaFutures {
 
   it should "not be invalid request without client credential when not required" in {
     val request = AuthorizationRequest(
-      Map(),
+      Map("Authorization" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVlOmNsaWVudF9zZWNyZXRfdmFsdWU=")),
       Map("grant_type" -> Seq("password"), "username" -> Seq("user"), "password" -> Seq("pass"), "scope" -> Seq("all"))
     )
 


### PR DESCRIPTION
@vargasbo @fxtickr @da4nik Guys, please take a look on this fix.
Basically the first element of the header "Authorization" was "Basic myencodedstring". So, before to perform proper decoding I filter keyword "Basic".
